### PR TITLE
Fix fixed-time scheduling delay

### DIFF
--- a/src/core/Scheduler.ts
+++ b/src/core/Scheduler.ts
@@ -60,6 +60,8 @@ export class Scheduler {
       }
     };
 
+    // Executa uma checagem imediata para evitar perder o horário
+    checkTime();
     // Faz a verificação a cada minuto
     setInterval(checkTime, 60 * 1000);
   }


### PR DESCRIPTION
## Summary
- run checkTime immediately before starting interval

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6843bc4799fc832b9db3f8b0f4a07e58