### PR TITLE
Fix fixed-time scheduling delay

### DIFF
--- a/src/core/Scheduler.ts
+++ b/src/core/Scheduler.ts
@@ -58,9 +58,16 @@ export class Scheduler {
       if (now.getHours() === hour && now.getMinutes() === minute) {
         this.runTask(task);
       }
+      scheduleNext();
     };
 
-    // Faz a verificação a cada minuto
-    setInterval(checkTime, 60 * 1000);
+    const scheduleNext = () => {
+      const now = new Date();
+      const delay = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+      setTimeout(checkTime, delay);
+    };
+
+    // Executa uma checagem imediata para evitar perder o horário
+    checkTime();
   }
 }


### PR DESCRIPTION
## Summary
- run checkTime immediately before starting interval
- adjust timing to check at minute boundaries using setTimeout

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6843bc4799fc832b9db3f8b0f4a07e58