### PR TITLE
Improve report handling

### DIFF
--- a/src/core/ExecutionReport.ts
+++ b/src/core/ExecutionReport.ts
@@ -12,6 +12,22 @@ export class ExecutionReport {
   private logs: ExecutionLog[] = [];
   private filePath = path.join(__dirname, "../../reports/executions.json");
 
+  constructor() {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    if (fs.existsSync(this.filePath)) {
+      try {
+        const data = fs.readFileSync(this.filePath, "utf8");
+        this.logs = JSON.parse(data);
+      } catch {
+        this.logs = [];
+      }
+    }
+  }
+
   logSuccess(taskId: string) {
     const log: ExecutionLog = {
       taskId,


### PR DESCRIPTION
## Summary
- ensure reports directory exists when logging executions
- load previous logs if `executions.json` already exists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843bc47e56c832ba726aa7fbddb6cdf